### PR TITLE
Correctly handle async resolves

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ watcher.subscribe(
 )
 
 export async function resolve(specifier, context, defaultResolve) {
-  const result = defaultResolve(specifier, context, defaultResolve)
+  const result = await defaultResolve(specifier, context, defaultResolve)
 
   const parent = context.parentURL ? new url.URL(context.parentURL) : null
   const child = new url.URL(result.url)


### PR DESCRIPTION
I was getting issues when I was trying this out because `defaultResolve` was returning a promise, causing `result.url` to be undefined. Adding the await fixed it for me.

The await doesn't seem to break anything else as far as I can tell.